### PR TITLE
Added option to reduce TTL when the header is shortened

### DIFF
--- a/src/Handler/TagHandler.php
+++ b/src/Handler/TagHandler.php
@@ -28,6 +28,8 @@ class TagHandler extends FOSTagHandler
     private $tagsHeader;
     /** @var int|null */
     private $tagsHeaderMaxLength;
+    /** @var int|null */
+    private $tagsHeaderReducedTTl;
     /** @var LoggerInterface */
     private $logger;
 
@@ -37,13 +39,15 @@ class TagHandler extends FOSTagHandler
         PurgeClientInterface $purgeClient,
         RepositoryTagPrefix $prefixService,
         LoggerInterface $logger,
-        $maxTagsHeaderLength = null
+        $maxTagsHeaderLength = null,
+        $tagsHeaderReducedTTl = null
     ) {
         $this->tagsHeader = $tagsHeader;
         $this->purgeClient = $purgeClient;
         $this->prefixService = $prefixService;
         $this->logger = $logger;
         $this->tagsHeaderMaxLength = $maxTagsHeaderLength;
+        $this->tagsHeaderReducedTTl = $tagsHeaderReducedTTl;
 
         parent::__construct($cacheManager, $tagsHeader);
         $this->addTags(['ez-all']);
@@ -96,6 +100,9 @@ class TagHandler extends FOSTagHandler
                 $tagsString = trim(substr($tagsString, 0, strrpos(
                     substr($tagsString, 0, $this->tagsHeaderMaxLength + 1), ' '
                 )));
+                if ($this->tagsHeaderReducedTTl && !$response->headers->getCacheControlDirective('s-maxage')) {
+                    $response->setSharedMaxAge($this->tagsHeaderReducedTTl);
+                }
                 $this->logger->warning(
                     'HTTP Cache tags header max length reached and truncated to ' . $this->tagsHeaderMaxLength
                 );

--- a/src/Handler/TagHandler.php
+++ b/src/Handler/TagHandler.php
@@ -100,7 +100,12 @@ class TagHandler extends FOSTagHandler
                 $tagsString = trim(substr($tagsString, 0, strrpos(
                     substr($tagsString, 0, $this->tagsHeaderMaxLength + 1), ' '
                 )));
-                if ($this->tagsHeaderReducedTTl && !$response->headers->getCacheControlDirective('s-maxage')) {
+                $responseSharedMaxAge = $response->headers->getCacheControlDirective('s-maxage');
+                if (
+                    $this->tagsHeaderReducedTTl &&
+                    $responseSharedMaxAge && 
+                    $this->tagsHeaderReducedTTl < $responseSharedMaxAge
+                ) {
                     $response->setSharedMaxAge($this->tagsHeaderReducedTTl);
                 }
                 $this->logger->warning(

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -2,6 +2,7 @@ parameters:
     ezplatform.http_cache.controller.invalidatetoken.class: EzSystems\PlatformHttpCacheBundle\Controller\InvalidateTokenController
     ezplatform.http_cache.listener.vary_header.class: EzSystems\PlatformHttpCacheBundle\EventListener\ConditionallyRemoveVaryHeaderListener
     ezplatform.http_cache.tags.header_max_length: null
+    ezplatform.http_cache.tags.header_reduced_ttl: null
 
 services:
     ezplatform.http_cache.cache_manager:
@@ -53,6 +54,7 @@ services:
          - '@ezplatform.http_cache.repository_tag_prefix'
          - '@logger'
          - '%ezplatform.http_cache.tags.header_max_length%'
+         - '%ezplatform.http_cache.tags.header_reduced_ttl%'
 
     ezplatform.http_cache.user_context_provider.role_identify:
         class: EzSystems\PlatformHttpCacheBundle\ContextProvider\RoleIdentify


### PR DESCRIPTION
It would be nice to offer the option to change TTL on the response when we know that `x-key` header was shortened due to the max length parameter.